### PR TITLE
fix(resolutions): Remove useless sleep call

### DIFF
--- a/index.js
+++ b/index.js
@@ -169,7 +169,6 @@ exports.snap = function (testContext, elem, resolutions) {
                     var width = resolution[0];
                     var height = resolution[1];
                     browser.driver.manage().window().setSize(width, height);
-                    browser.sleep(175);
                     exports.snap(testContext, elem);
                 };
                 return flow.execute(takeEachScreenshotFn);


### PR DESCRIPTION
There was a case where resizing the nav bar to something too small to
contain it caused the unrendered parts of the nav bar to appear
white. At first I thought it was because I took the screenshot too
fast, so I tried sleeping for a little while before taking
screenshots. Later, I realized what was actually going on.