### PR TITLE
chore(npm): Use fork of node-resemble

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "fs-extra": "^0.18.2",
     "lodash": "^3.7.0",
     "lwip": "0.0.7",
-    "node-resemble": "^1.1.3",
+    "node-resemble": "droogans/node-resemble#6b8f3d0",
     "zfill": "0.0.2"
   },
   "devDependencies": {


### PR DESCRIPTION
Until node-canvas can be built on latest, force node-resemble to use
1.2.3, which isn't in the official repository yet.

Use a quick fork and branch that is pinned to 1.2.3, just to keep
things building.