### PR TITLE
feat(branches): Support off-master screenshot catalogs

### DIFF
--- a/bin/ci-helpers.js
+++ b/bin/ci-helpers.js
@@ -502,16 +502,9 @@ function findTargetBranch(repoUrl, pullRequestNumber) {
  * `branchName` must be an exact match the the branch you're looking for.
  */
 function branchExists(branchName) {
-    let branches = '';
-    try {
-        cmds = [
-            `cd ${config.snappit.screenshotsDirectory}`,
-            `git branch -a --no-color | grep "^  remotes/origin/${branchName}$"`,
-            `cd ..`
-        ].join('; ');
-        branches = execSync(cmds).toString('utf-8');
-    } catch (e) {}
-    return Boolean(branches.length);
+    let u = buildApiUrl(repoUrl, `/repos${repoUrl.path}/branches/${branchName}`);
+    let branches = JSON.parse(execSync(`curl ${buildCurlFlags()} ${u.href} 2>/dev/null`).toString('utf-8'));
+    return branches.message === undefined;
 };
 
 /**

--- a/bin/ci-helpers.js
+++ b/bin/ci-helpers.js
@@ -285,18 +285,26 @@ function createForkAndClone() {
         }
 
         cloneRepo(screenshotsRepo);
+        configureGitUser();
         findAndCreateTargetBranch();
     });
 };
 
-function commitScreenshots() {
+function configureGitUser() {
+    console.log(`Preparing service account ${userName} to commit locally.`);
     let cmds = [
-        `pwd`,
         `cd ${config.snappit.screenshotsDirectory}`,
-        `pwd`,
-        `git checkout -b ${config.snappit.cicd.messages.branchName(getVars())}`,
         `git config user.name "${userName}"`,
         `git config user.email "${config.snappit.cicd.serviceAccount.userEmail}"`,
+        `cd ..`
+    ];
+    cmd(cmds.join('; '));
+};
+
+function commitScreenshots() {
+    let cmds = [
+        `cd ${config.snappit.screenshotsDirectory}`,
+        `git checkout -b ${config.snappit.cicd.messages.branchName(getVars())}`,
         `git add -A`,
         `git status -sb`,
         `git commit -m "${config.snappit.cicd.messages.commitMessage(getVars())}"`

--- a/bin/ci-helpers.js
+++ b/bin/ci-helpers.js
@@ -286,7 +286,7 @@ function createForkAndClone() {
 
         cloneRepo(screenshotsRepo);
         configureGitUser();
-        findAndCreateTargetBranch();
+        createTargetBranch();
     });
 };
 
@@ -475,7 +475,7 @@ function findSha(repoUrl, pullRequestNumber) {
  * screenshot repository's 2.x branch. If you do not have a "2.x" branch yet in your screenshots repository,
  * it will be created for you.
  */
-function findAndCreateTargetBranch() {
+function createTargetBranch() {
     let projectTargetBranchName = getVars().targetBranch;
     if (!branchExists(projectTargetBranchName)) {
         console.log(`No branch to merge against: target branch ${projectTargetBranchName}. Creating...`);
@@ -484,7 +484,6 @@ function findAndCreateTargetBranch() {
         let pushUpstream = true;
         pushCommit(pushUpstream, projectTargetBranchName);
     }
-    return projectTargetBranchName;
 };
 
 /**
@@ -505,7 +504,12 @@ function findTargetBranch(repoUrl, pullRequestNumber) {
 function branchExists(branchName) {
     let branches = '';
     try {
-        branches = execSync(`git branch -a --no-color | grep "  remotes/origin/${branchName}$"`).toString('utf-8');
+        cmds = [
+            `cd ${config.snappit.screenshotsDirectory}`,
+            `git branch -a --no-color | grep "^  remotes/origin/${branchName}$"`,
+            `cd ..`
+        ].join('; ');
+        branches = execSync(cmds).toString('utf-8');
     } catch (e) {}
     return Boolean(branches.length);
 };

--- a/bin/ci-helpers.js
+++ b/bin/ci-helpers.js
@@ -307,7 +307,8 @@ function commitScreenshots() {
         `git checkout -b ${config.snappit.cicd.messages.branchName(getVars())}`,
         `git add -A`,
         `git status -sb`,
-        `git commit -m "${config.snappit.cicd.messages.commitMessage(getVars())}"`
+        `git commit -m "${config.snappit.cicd.messages.commitMessage(getVars())}"`,
+        `cd ..`
     ];
     try {
         cmd(cmds.join('; '));
@@ -326,7 +327,8 @@ function pushCommit(pushUpstream, branchName) {
     // don't log any of this information out to the console!
     let sensitiveCommand = [
         `cd ${config.snappit.screenshotsDirectory}`,
-        `git push ${pushUrl} ${branchName}`
+        `git push ${pushUrl} ${branchName}`,
+        `cd ..`
     ].join('; ');
 
     cmd(sensitiveCommand);
@@ -519,7 +521,7 @@ function checkoutOrphanedBranch(branchName) {
         `git checkout --orphan ${branchName} $(git rev-list --max-parents=0 HEAD)`,
         // delete everything that we care about (directories that aren't the .git directory)
         `find . -maxdepth 1 -mindepth 1 -type d | grep -v "./\.git" | xargs rm -rf`,
-        `git commit --allow-empty -m "chore(${branchName}): Initialize branch ${branchName}"`,
+        `git commit --allow-empty -m "chore(branch): Initialize new branch '${branchName}'"`,
         `cd ..`
     ];
     try {

--- a/bin/ci-helpers.js
+++ b/bin/ci-helpers.js
@@ -304,6 +304,7 @@ function configureGitUser() {
 function commitScreenshots() {
     let cmds = [
         `cd ${config.snappit.screenshotsDirectory}`,
+        `git checkout ${getVars().targetBranch}`,
         `git checkout -b ${config.snappit.cicd.messages.branchName(getVars())}`,
         `git add -A`,
         `git status -sb`,
@@ -504,7 +505,7 @@ function findTargetBranch(repoUrl, pullRequestNumber) {
 function branchExists(branchName) {
     let branches = '';
     try {
-        branches = execSync(`git branch --no-color | grep "[\* |  ]${branchName}"`).toString('utf-8');
+        branches = execSync(`git branch -a --no-color | grep "  remotes/origin/${branchName}$"`).toString('utf-8');
     } catch (e) {}
     return Boolean(branches.length);
 };

--- a/bin/ci-helpers.js
+++ b/bin/ci-helpers.js
@@ -21,10 +21,13 @@ if (args[0] === undefined) {
 let config = configOptions.fromProtractorConf(args[0]);
 
 let projectRepo = url.parse(config.snappit.cicd.projectRepo);
-let screenshotsRepo = url.parse(config.snappit.cicd.screenshotsRepo);
-let repoName = _.last(screenshotsRepo.path.split('/'));
+let projectRepoName = _.last(projectRepo.path.split('/'))
 let projectOrg = projectRepo.path.match(/\/.*\//)[0].replace(/\//g, '');
+
+let screenshotsRepo = url.parse(config.snappit.cicd.screenshotsRepo);
+let screenshotsRepoName = _.last(screenshotsRepo.path.split('/'));
 let screenshotsOrg = screenshotsRepo.path.match(/\/.*\//)[0].replace(/\//g, '');
+
 let userName = config.snappit.cicd.serviceAccount.userName;
 let token = process.env[config.snappit.cicd.githubTokenEnvironmentVariable];
 
@@ -270,7 +273,7 @@ function createForkAndClone() {
     // will either create a repo (if it doesn't exist), or return a message stating that it does exist
     return repoAction.then(message => {
         console.log(message);
-        let forkedRepo = url.parse(`https://${screenshotsRepo.hostname}/${userName}/${repoName}`);
+        let forkedRepo = url.parse(`https://${screenshotsRepo.hostname}/${userName}/${screenshotsRepoName}`);
         if (!repositoryExists(forkedRepo)) {
             return forkRepository(screenshotsRepo).then((message) => {
                 console.log(message);
@@ -323,7 +326,7 @@ function pushCommit(pushUpstream, branchName) {
         branchName = config.snappit.cicd.messages.branchName(getVars());
     }
 
-    let pushUrl = `https://${token}@${screenshotsRepo.hostname}/${destination}/${repoName}.git`;
+    let pushUrl = `https://${token}@${screenshotsRepo.hostname}/${destination}/${screenshotsRepoName}.git`;
 
     // don't log any of this information out to the console!
     let sensitiveCommand = [
@@ -520,7 +523,7 @@ function checkoutOrphanedBranch(branchName) {
         `git checkout --orphan ${branchName} $(git rev-list --max-parents=0 HEAD)`,
         // delete everything that we care about (directories that aren't the .git directory)
         `find . -maxdepth 1 -mindepth 1 -type d | grep -v "./\.git" | xargs rm -rf`,
-        `git commit --allow-empty -m "Start new screenshot catalog for ${projectOrg}/${repoName}:${branchName}"`,
+        `git commit --allow-empty -m "Start new screenshot catalog for ${projectOrg}/${projectRepoName}:${branchName}"`,
         `cd ..`
     ];
     try {

--- a/bin/ci-helpers.js
+++ b/bin/ci-helpers.js
@@ -511,6 +511,7 @@ function checkoutOrphanedBranch(branchName) {
         `git checkout --orphan ${branchName} $(git rev-list --max-parents=0 HEAD)`,
         // delete everything that we care about (directories that aren't the .git directory)
         `find . -maxdepth 1 -mindepth 1 -type d | grep -v "./\.git" | xargs rm -rf`,
+        `git commit --allow-empty -m "chore(${branchName}): Initialize branch ${branchName}"`,
         `cd ..`
     ];
     try {

--- a/bin/ci-helpers.js
+++ b/bin/ci-helpers.js
@@ -318,10 +318,10 @@ function pushCommit(pushUpstream, branchName) {
     // don't log any of this information out to the console!
     let sensitiveCommand = [
         `cd ${config.snappit.screenshotsDirectory}`,
-        `git push ${pushUrl} ${branchName} > /dev/null 2>&1`
+        `git push ${pushUrl} ${branchName}`
     ].join('; ');
 
-    execSync(sensitiveCommand);
+    cmd(sensitiveCommand);
 };
 
 function makePullRequest(repoUrl) {

--- a/bin/ci-helpers.js
+++ b/bin/ci-helpers.js
@@ -22,6 +22,7 @@ let config = configOptions.fromProtractorConf(args[0]);
 
 let projectRepo = url.parse(config.snappit.cicd.projectRepo);
 let screenshotsRepo = url.parse(config.snappit.cicd.screenshotsRepo);
+let repoName = _.last(screenshotsRepo.path.split('/'));
 let projectOrg = projectRepo.path.match(/\/.*\//)[0].replace(/\//g, '');
 let screenshotsOrg = screenshotsRepo.path.match(/\/.*\//)[0].replace(/\//g, '');
 let userName = config.snappit.cicd.serviceAccount.userName;
@@ -48,7 +49,7 @@ let actions = {
 
     push: {
         description: descriptions.pushDescription,
-        fn: () => pushCommit(screenshotsRepo)
+        fn: () => pushCommit
     },
 
     pr: {
@@ -88,7 +89,8 @@ function getSupportedCIEnvironments() {
                     return process.env.TRAVIS_BRANCH;
                 }
                 return findBranchName(projectRepo, this.pullRequestNumber);
-            }
+            },
+            get targetBranch() { return findTargetBranch(projectRepo, this.pullRequestNumber); }
         },
 
         codeship: {
@@ -98,7 +100,8 @@ function getSupportedCIEnvironments() {
             get sha1() { return process.env.CI_COMMIT_ID.slice(0, 7); },
             // codeship builds when new commits are pushed, not when pull requests are opened
             get pullRequestNumber() { return findPullRequestNumber(projectRepo, this.branch); },
-            get branch() { return process.env.CI_BRANCH; }
+            get branch() { return process.env.CI_BRANCH; },
+            get targetBranch() { return findTargetBranch(projectRepo, this.pullRequestNumber); }
         },
 
         jenkins: {
@@ -107,7 +110,8 @@ function getSupportedCIEnvironments() {
             get repoSlug() { return projectRepo.path.slice(1); },
             get sha1() { return findSha(projectRepo, this.pullRequestNumber).slice(0, 7); },
             get pullRequestNumber() { return process.env.sha1.match(/pr\/(\d+)\/merge/)[1]; },
-            get branch() { return findBranchName(projectRepo, this.pullRequestNumber); }
+            get branch() { return findBranchName(projectRepo, this.pullRequestNumber); },
+            get targetBranch() { return findTargetBranch(projectRepo, this.pullRequestNumber); }
         },
 
         undefined: {
@@ -116,7 +120,8 @@ function getSupportedCIEnvironments() {
             get repoSlug() { return projectRepo.path.slice(1); },
             get sha1() { return 'sha1-unavailable'; },
             get pullRequestNumber() { return 'pull-request-number-unavailable'; },
-            get branch() { return 'branch-unavailable'; }
+            get branch() { return 'branch-unavailable'; },
+            get targetBranch() { return 'target-branch-unavailable'; }
         }
     };
 };
@@ -244,6 +249,13 @@ function cloneRepo(repoUrl) {
     console.log(`Cloned a submodule for screenshots in directory "${repoUrl.href}"`);
 };
 
+/**
+ * This will create a screenshots repo, if it does not exist, then it will create a fork of that
+ * using your service account's credentials. It will then clone it as a submodule into your project.
+ * Afterwards, it will find out what the target branch is in the project repo's pull request, and configure
+ * the submodule of your screenshot repository to mimic that branch set up.
+ * @see findAndCreateTargetBranch
+ */
 function createForkAndClone() {
     if (!repositoryExists(projectRepo)) {
         throw new Error(`Main project repo ${projectRepo.href} does not exist! Create it first, then retry.`);
@@ -258,7 +270,6 @@ function createForkAndClone() {
     // will either create a repo (if it doesn't exist), or return a message stating that it does exist
     return repoAction.then(message => {
         console.log(message);
-        let repoName = _.last(screenshotsRepo.path.split('/'));
         let forkedRepo = url.parse(`https://${screenshotsRepo.hostname}/${userName}/${repoName}`);
         if (!repositoryExists(forkedRepo)) {
             return forkRepository(screenshotsRepo).then((message) => {
@@ -274,6 +285,7 @@ function createForkAndClone() {
         }
 
         cloneRepo(screenshotsRepo);
+        findAndCreateTargetBranch();
     });
 };
 
@@ -294,14 +306,19 @@ function commitScreenshots() {
     } catch (e) { /* Nothing to commit */ }
 };
 
-function pushCommit() {
+function pushCommit(pushUpstream, branchName) {
     // pushes to the fork created by the service account by default, not the main screenshots repo
-    let repoName = _.last(screenshotsRepo.path.split('/'));
-    let pushUrl = `https://${token}@${screenshotsRepo.hostname}/${userName}/${repoName}.git`;
+    let destination = pushUpstream ? projectOrg : userName;
+    if (branchName === undefined) {
+        branchName = config.snappit.cicd.messages.branchName(getVars());
+    }
+
+    let pushUrl = `https://${token}@${screenshotsRepo.hostname}/${destination}/${repoName}.git`;
+
     // don't log any of this information out to the console!
     let sensitiveCommand = [
         `cd ${config.snappit.screenshotsDirectory}`,
-        `git push ${pushUrl} ${config.snappit.cicd.messages.branchName(getVars())} > /dev/null 2>&1`
+        `git push ${pushUrl} ${branchName} > /dev/null 2>&1`
     ].join('; ');
 
     execSync(sensitiveCommand);
@@ -313,7 +330,7 @@ function makePullRequest(repoUrl) {
         title: config.snappit.cicd.messages.pullRequestTitle(getVars()),
         body: config.snappit.cicd.messages.pullRequestBody(getVars()),
         head: `${userName}:${config.snappit.cicd.messages.branchName(getVars())}`,
-        base: config.snappit.cicd.targetBranch
+        base: config.snappit.cicd.targetBranch || getVars().targetBranch
     };
 
     let options = {
@@ -428,4 +445,75 @@ function findSha(repoUrl, pullRequestNumber) {
     if (pullRequest.message === undefined) {
         return pullRequest.head.sha;
     }
+};
+
+/**
+ * Find the current target branch for the project's pull request. If this target branch does not yet exist
+ * in the screenshots repository, it will be created.
+ *
+ * Why:
+ * Not all screenshot pull request should target the master branch.
+ * For projects that support multiple versions of the same project (e.g., a long running 2.x branch
+ * while simultaneously supporting a 1.x version on `master`), this will designate all screenshots to
+ * merge into a branch that is named the same as the branch the project's pull request is targeting.
+ *
+ * Example:
+ * A pull request is opened against master, `feature-for-master`. The screenshots for that pull request
+ * will be made against the screenshot repository's master branch. Another pull request is opened against
+ * the 2.x branch, `feature-for-2.x`. The screenshots for *that* pull request will be made against the
+ * screenshot repository's 2.x branch. If you do not have a "2.x" branch yet in your screenshots repository,
+ * it will be created for you.
+ */
+function findAndCreateTargetBranch() {
+    let projectTargetBranchName = getVars().targetBranch;
+    if (!branchExists(projectTargetBranchName)) {
+        console.log(`No branch to merge against: target branch ${projectTargetBranchName}. Creating...`);
+        checkoutOrphanedBranch(projectTargetBranchName);
+        // doesn't actually push the "commit", but will push this new branch up
+        let pushUpstream = true;
+        pushCommit(pushUpstream, projectTargetBranchName);
+    }
+    return projectTargetBranchName;
+};
+
+/**
+ * Get the name of the branch the the project's pull request is targeting.
+ * Most of the time, this is "master".
+ */
+function findTargetBranch(repoUrl, pullRequestNumber) {
+    let u = buildApiUrl(repoUrl, `/repos${repoUrl.path}/pulls/${pullRequestNumber}`);
+    let pullRequest = JSON.parse(execSync(`curl ${buildCurlFlags()} ${u.href} 2>/dev/null`).toString('utf-8'));
+    if (pullRequest.message === undefined) {
+        return pullRequest.base.ref;
+    }
+};
+
+/**
+ * `branchName` must be an exact match the the branch you're looking for.
+ */
+function branchExists(branchName) {
+    let branches = '';
+    try {
+        branches = execSync(`git branch --no-color | grep "[\* |  ]${branchName}"`).toString('utf-8');
+    } catch (e) {}
+    return Boolean(branches.length);
+};
+
+/**
+ * Will create a branch that has absolutely no history in common with the project, save for the first commit.
+ * For repositories generated with this tool, will include only a single "Initial Commit" parent commit.
+ */
+function checkoutOrphanedBranch(branchName) {
+    let cmds = [
+        `cd ${config.snappit.screenshotsDirectory}`,
+        // check out an orphaned (no history) branch http://stackoverflow.com/a/4288660/881224
+        // and set its parent to the first commit (inital commit) http://stackoverflow.com/a/1007545/881224
+        `git checkout --orphan ${branchName} $(git rev-list --max-parents=0 HEAD)`,
+        // delete everything that we care about (directories that aren't the .git directory)
+        `find . -maxdepth 1 -mindepth 1 -type d | grep -v "./\.git" | xargs rm -rf`,
+        `cd ..`
+    ];
+    try {
+        cmd(cmds.join('; '));
+    } catch (e) { /* Nothing to commit */ }
 };

--- a/bin/ci-helpers.js
+++ b/bin/ci-helpers.js
@@ -52,7 +52,7 @@ let actions = {
 
     push: {
         description: descriptions.pushDescription,
-        fn: () => pushCommit
+        fn: pushCommit
     },
 
     pr: {
@@ -321,7 +321,7 @@ function commitScreenshots() {
 
 function pushCommit(pushUpstream, branchName) {
     // pushes to the fork created by the service account by default, not the main screenshots repo
-    let destination = pushUpstream ? projectOrg : userName;
+    let destination = pushUpstream ? screenshotsOrg : userName;
     if (branchName === undefined) {
         branchName = config.snappit.cicd.messages.branchName(getVars());
     }

--- a/bin/config.js
+++ b/bin/config.js
@@ -11,7 +11,7 @@ let setConfigDefaults = config => {
 
     config.snappit.cicd = _.defaults(config.snappit.cicd, {
         githubTokenEnvironmentVariable: 'ghToken',
-        targetBranch: 'master',
+        targetBranch: undefined, // will default to project pull request's target branch
         privateRepo: false,
         ignoreSSLWarnings: false,
         githubEnterprise: false


### PR DESCRIPTION
This will allow you to track separate sets of screenshots for pull requests
from your project that target branches other than the master branch. For
instance, if you use the "git flow" approach to releasing new features,
you will have a master branch for production, and a long running "dev"
branch that gets periodically merged with master. With this new configuration,
you can automatically generate independent sets of screenshots that are
tracked against each branch. The screenshot pull requests will target either
the master or the dev branch, depending on the target branch in the project's
pull request.