### PR TITLE
feat(branches): Support off-master screenshot catalogs

### DIFF
--- a/bin/config.js
+++ b/bin/config.js
@@ -11,7 +11,7 @@ let setConfigDefaults = config => {
 
     config.snappit.cicd = _.defaults(config.snappit.cicd, {
         githubTokenEnvironmentVariable: 'ghToken',
-        targetBranch: 'master',
+        targetBranch: undefined, // will default to project pull request's target branch
         privateRepo: false,
         ignoreSSLWarnings: false,
         githubEnterprise: false


### PR DESCRIPTION
This will allow you to track separate sets of screenshots for pull requests
from your project that target branches other than the master branch. For
instance, if you use the "git flow" approach to releasing new features,
you will have a master branch for production, and a long running "dev"
branch that gets periodically merged with master. With this new configuration,
you can automatically generate independent sets of screenshots that are
tracked against each branch. The screenshot pull requests will target either
the master or the dev branch, depending on the target branch in the project's
pull request.