### PR TITLE
fix(paths): Don't use __dirname when exporting a node module

### DIFF
--- a/index.js
+++ b/index.js
@@ -50,7 +50,7 @@ let getScreenshotNameFromContext = (testContext, options) => {
     return browser.getCapabilities().then(capabilities => {
         let resolutionString = `${zfill(resolution.width, 4)}x${zfill(resolution.height, 4)}`;
         let browserName = capabilities.get('browserName');
-        let screenshotDir = path.resolve(__dirname, module.exports.screenshotsDirectory, browserName);
+        let screenshotDir = path.resolve(module.exports.screenshotsDirectory, browserName);
         let test = util.handleMochaHooks(testContext);
         let fullyQualifiedPath = test.file.split('/');
         let commonPath = _.takeWhile(path.resolve(__dirname).split('/'), (directoryPart, index) => {


### PR DESCRIPTION
This causes the current directory to show up right where you'd expect it
to be -- right in `./node_modules/snappit-mocha-protractor`, breaking
this tool's ability to properly place screenshots inside of a directory.