### PR TITLE
Update lwip to 0.0.9 to support Node 6

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "chalk": "1.1.1",
     "fs-extra": "0.26.5",
     "lodash": "4.8.2",
-    "lwip": "0.0.8",
+    "lwip": "0.0.9",
     "node-resemble": "1.1.3"
   },
   "devDependencies": {


### PR DESCRIPTION
lwip 0.0.8 fails to compile under Node 6.